### PR TITLE
Integrate Anne van Rossum encryption code, add rgbColor routine

### DIFF
--- a/index.js
+++ b/index.js
@@ -324,7 +324,7 @@ Lumen.prototype.color = function(c, m, y, k, callback) {
   var g = 1. - (m-k);
   var b = 1. - (y-k);
 
-  this.rgbColor([r*100, g*100, b*100], callback);
+  this.rgbColor([r*99, g*99, b*99], callback);
 };
 
 /* Parameters:  color:[r,b,g] in range 0-99 */

--- a/index.js
+++ b/index.js
@@ -275,7 +275,7 @@ Lumen.prototype.readState = function(callback) {
         state.colorC = c - k;
         state.colorM = m - k;
         state.colorY = y - k;
-        state.colorW = k;
+        state.colorW = 1. - k;
       }
     }
     state.mode = mode;
@@ -317,8 +317,10 @@ Lumen.prototype.warmWhite = function(percentage, callback) {
   writeCommand(this, [0x01, 0x00, 0x00, 0x00, zeroto99], callback)
 };
 
-/* Parameters:  c,m,y,k in range 0.0-1.0 */
-Lumen.prototype.color = function(c, m, y, k, callback) {
+/* Parameters:  c,m,y,w in range 0.0-1.0 */
+Lumen.prototype.color = function(c, m, y, w, callback) {
+  var k = 1. - w
+
   // standard c m y k -> rgb conversion
   var r = 1. - (c-k);
   var g = 1. - (m-k);

--- a/index.js
+++ b/index.js
@@ -277,6 +277,8 @@ Lumen.prototype.readState = function(callback) {
 
         // TODO fix decryptCommand and retrieve decrypted rgb color
         //~ var decrypted = decryptCommand(data);
+        console.log(">>", data);
+        console.log(">>>", decrypted);
 
         state.colorC = (data[1] - 120.0) / 105.0;
         state.colorM = (data[2] - 120.0) / 105.0;
@@ -419,16 +421,18 @@ function encryptCommand(buffer) {
 }
 
 function decryptCommand (data) {
-  var string = data.toString('ascii');
-  var buf = new Uint8Array(20);
+  var data = new Buffer(data);
+  var buf = new Buffer(20);
 
-  for (var i=0; i<string.length; i++) {
-    buf[i] = string.charCodeAt(i);
-  }
+  for (var i=0; i<data.length; i++)
+    buf[i] = data[i];
 
   // Decrypt data
   xor(buf, SERVICE_KEYXOR);
   subtract(buf, SERVICE_KEYADD);
+
+  // Set 'on' bit
+  buf[0] = 0x01 & data[0];
 
   return buf;
 }

--- a/index.js
+++ b/index.js
@@ -327,39 +327,8 @@ Lumen.prototype.normalMode = function(callback) {
 };
 
 Lumen.prototype.warmWhite = function(percentage, callback) {
-  if (percentage < 0) {
-    percentage = 0;
-  } else if (percentage > 100) {
-    percentage = 100;
-  }
-
-  this._service1Data[0] = 0x01;
-  this._service1Data[1] = 0xdf;
-  this._service1Data[2] = 0xd9;
-
-  this._service1Data[6] = 0x54;
-
-  if (percentage >= 100) {
-    this._service1Data[3] = 0x9a;
-    this._service1Data[4] = 0x58;
-  } else if (percentage >= 90) {
-    this._service1Data[3] = 0x9b;
-    this._service1Data[4] = 0xa3;
-  } else if (percentage >= 70) {
-    this._service1Data[3] = 0x9b;
-    this._service1Data[4] = 0xb5;
-  } else if (percentage >= 50) {
-    this._service1Data[3] = 0x9b;
-    this._service1Data[4] = 0x87;
-  } else if (percentage >= 30) {
-    this._service1Data[3] = 0x9b;
-    this._service1Data[4] = 0x99;
-  } else {
-    this._service1Data[3] = 0x9b;
-    this._service1Data[4] = 0xf2;
-  }
-
-  this.writeService1(this._service1Data, callback);
+  zeroto99 = Math.max(0, Math.min(percentage, 99))
+  _writeCommand(this, [0x01, 0x00, 0x00, 0x00, zeroto99], callback)
 };
 
 Lumen.prototype.color = function(c, m, y, w, callback) {

--- a/index.js
+++ b/index.js
@@ -28,14 +28,6 @@ var SERVICE_5_UUID                          = 'fff5';
 var SERVICE_KEYADD = new Uint8Array([0, 244, 229, 214, 163, 178, 163, 178, 193, 244, 229, 214, 163, 178, 193, 244, 229, 214, 163, 178]);
 var SERVICE_KEYXOR = new Uint8Array([0, 43, 60, 77, 94, 111, 247, 232, 217, 202, 187, 172, 157, 142, 127, 94, 111, 247, 232, 217]);
 
-function _writeCommand(_this, cmd, callback) {
-  var buf = new Buffer(cmd);
-  var encrypted = _this.encryptCommand(buf);
-  // TODO remove debug
-  console.log(encrypted)
-  _this.writeService1(encrypted, callback);
-}
-
 function Lumen(peripheral) {
   this._peripheral = peripheral;
   this._services = {};
@@ -299,36 +291,36 @@ Lumen.prototype.readState = function(callback) {
 };
 
 Lumen.prototype.turnOff = function(callback) {
-  _writeCommand(this, [0x0, ], callback)
+  writeCommand(this, [0x0, ], callback)
 };
 
 Lumen.prototype.turnOn = function(callback) {
-  _writeCommand(this, [0x01, 0x00, 0x00, 0x00, 0x0, 0x0, 0x48], callback)
+  writeCommand(this, [0x01, 0x00, 0x00, 0x00, 0x0, 0x0, 0x48], callback)
 };
 
 Lumen.prototype.coolMode = function(callback) {
-  _writeCommand(this, [0x01, 0x00, 0x00, 0x00, 0x0, 0x0, 0x04], callback)
+  writeCommand(this, [0x01, 0x00, 0x00, 0x00, 0x0, 0x0, 0x04], callback)
 };
 
 Lumen.prototype.warmMode = function(callback) {
-  _writeCommand(this, [0x01, 0x00, 0x00, 0x00, 0x0, 0x0, 0x03], callback)
+  writeCommand(this, [0x01, 0x00, 0x00, 0x00, 0x0, 0x0, 0x03], callback)
 };
 
 Lumen.prototype.disco1Mode = function(callback) {
-  _writeCommand(this, [0x01, 0x00, 0x00, 0x00, 0x0, 0x0, 0x02], callback)
+  writeCommand(this, [0x01, 0x00, 0x00, 0x00, 0x0, 0x0, 0x02], callback)
 };
 
 Lumen.prototype.disco2Mode = function(callback) {
-  _writeCommand(this, [0x01, 0x00, 0x00, 0x00, 0x0, 0x0, 0x01], callback)
+  writeCommand(this, [0x01, 0x00, 0x00, 0x00, 0x0, 0x0, 0x01], callback)
 };
 
 Lumen.prototype.normalMode = function(callback) {
-  _writeCommand(this, [0x01, ], callback)
+  writeCommand(this, [0x01, ], callback)
 };
 
 Lumen.prototype.warmWhite = function(percentage, callback) {
   zeroto99 = Math.max(0, Math.min(percentage, 99))
-  _writeCommand(this, [0x01, 0x00, 0x00, 0x00, zeroto99], callback)
+  writeCommand(this, [0x01, 0x00, 0x00, 0x00, zeroto99], callback)
 };
 
 /* Parameters:  c,m,y,k in range 0.0-1.0 */
@@ -350,8 +342,10 @@ Lumen.prototype.rgbColor = function (color, callback) {
     cmd[i+1] = Math.min(Math.max(0, parseInt(color[i])), 99);
   }
 
-  _writeCommand(this, cmd, callback);
+  writeCommand(this, cmd, callback);
 }
+
+/*----------------- Utility functions -----------------*/
 
 function add(array, key) {
   var i = 0;
@@ -402,7 +396,7 @@ function xor(array, key) {
   }
 }
 
-Lumen.prototype.encryptCommand = function(buffer) {
+function encryptCommand(buffer) {
   var data = new Buffer(20);
 
   // Set buffer data
@@ -424,7 +418,7 @@ Lumen.prototype.encryptCommand = function(buffer) {
   return data;
 }
 
-Lumen.prototype.decryptCommand = function (data) {
+function decryptCommand (data) {
   var string = data.toString('ascii');
   var buf = new Uint8Array(20);
 
@@ -437,6 +431,14 @@ Lumen.prototype.decryptCommand = function (data) {
   subtract(buf, SERVICE_KEYADD);
 
   return buf;
+}
+
+function writeCommand(_this, cmd, callback) {
+  var buf = new Buffer(cmd);
+  var encrypted = encryptCommand(buf);
+  // TODO remove debug
+  console.log(encrypted)
+  _this.writeService1(encrypted, callback);
 }
 
 module.exports = Lumen;

--- a/index.js
+++ b/index.js
@@ -248,6 +248,10 @@ Lumen.prototype.readState = function(callback) {
 
     var mode = MODE_MAPPER[data[6]] || 'unknown';
 
+    var decrypted = decryptCommand(data);
+    console.log(">>", data);
+    console.log(">>>", decrypted);
+
     if (mode === 'normal') {
       if ((data[1] === 0xdf) &&
             (data[2] === 0xd9) &&
@@ -274,11 +278,6 @@ Lumen.prototype.readState = function(callback) {
           (state.warmWhitePercentage === undefined || state.warmWhitePercentage === 'unknown')) {
         mode = 'color';
         state.warmWhitePercentage = undefined;
-
-        // TODO fix decryptCommand and retrieve decrypted rgb color
-        //~ var decrypted = decryptCommand(data);
-        console.log(">>", data);
-        console.log(">>>", decrypted);
 
         state.colorC = (data[1] - 120.0) / 105.0;
         state.colorM = (data[2] - 120.0) / 105.0;
@@ -379,7 +378,7 @@ function subtract(array, key) {
   {
     var j = 0xff & abyte1[i + 1];
     var k = 0xff & abyte2[i + 1];
-    var c1 = '\0';
+    var c1 = 0;
     if(j < k)
     {
       abyte1[i] = (-1 + abyte1[i]);


### PR DESCRIPTION
Current implementation does not work very well with colors. Anne van Rossum has exploited the lumen encryption mechanism (see https://github.com/mrquincle/luminosi) and provided code which allows precise rgb color control. I've integrated them with node-lumen existing module code. It would be nice to join the two projects together.
Please note that since current decryption implementation does not work, device state color reading still uses old code.
